### PR TITLE
hotfix: check if 'az login' outputs an empty json list

### DIFF
--- a/nixos/maintainers/scripts/azure-new/boot-vm.sh
+++ b/nixos/maintainers/scripts/azure-new/boot-vm.sh
@@ -6,7 +6,7 @@
 
 # Making  sure  that  one   is  logged  in  (to  avoid
 # surprises down the line).
-if [ $(az account list 2> /dev/null) == [] ]
+if [ $(az account list | jq -r 'length') -eq 0 ]
 then
   echo
   echo '********************************************************'

--- a/nixos/maintainers/scripts/azure-new/shell.nix
+++ b/nixos/maintainers/scripts/azure-new/shell.nix
@@ -9,6 +9,7 @@ pkgs.mkShell {
     # https://gist.github.com/CMCDragonkai/1ae4f4b5edeb021ca7bb1d271caca999
     cacert
     azure-storage-azcopy
+    jq
   ];
 
   AZURE_CONFIG_DIR="/tmp/azure-cli/.azure";

--- a/nixos/maintainers/scripts/azure-new/upload-image.sh
+++ b/nixos/maintainers/scripts/azure-new/upload-image.sh
@@ -6,10 +6,7 @@
 
 # Making  sure  that  one   is  logged  in  (to  avoid
 # surprises down the line).
-# TODO Works flawlessly when  not logged in, but shows
-#      error when do logged in.
-#      > ./upload-image.sh: line 126: [: too many arguments
-if [ $(az account list 2> /dev/null) = [] ]
+if [ $(az account list | jq -r 'length') -eq 0 ]
 then
   echo
   echo '********************************************************'


### PR DESCRIPTION
I'm currently testing this tool in my Azure accounts, this error popped up and I looked at some of the script's comments.